### PR TITLE
Fix leaderboards

### DIFF
--- a/app/models/tomato.rb
+++ b/app/models/tomato.rb
@@ -52,7 +52,7 @@ class Tomato
   end
 
   def self.ranking_collection(time_period)
-    map_reduce(ranking_map(time_period), ranking_reduce).out({:replace => "user_ranking_#{time_period}s"})
+    map_reduce(ranking_map(time_period), ranking_reduce).out({:replace => "user_ranking_#{time_period}s"}).entries
   end
 
   def self.by_day(tomatoes)


### PR DESCRIPTION
In the previous codebase Rails was caching the mongoid map_reduce definition instead of the real data.