### PR TITLE
Add a default session store secret token

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -4,4 +4,4 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-TomatoesApp::Application.config.secret_token = ENV["SESSION_STORE_SECRET_TOKEN"]
+TomatoesApp::Application.config.secret_token = ENV['SESSION_STORE_SECRET_TOKEN'] || 'df4a92e8e3f5306c421693fc5d7a8bea'


### PR DESCRIPTION
A session store secret token is alwasy needed, but in development it's fine to use a random string.

Supersedes https://github.com/potomak/tomatoes/pull/150