### PR TITLE
Add DELETE /session endpoint

### DIFF
--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -1,5 +1,8 @@
 module Api
   class SessionsController < BaseController
+    before_action :authenticate_user!, only: :destroy
+
+    # POST /session
     def create
       auth_provider = AuthFactory.build(params)
       user = auth_provider.find_user
@@ -14,6 +17,13 @@ module Api
       bad_request 'provider not supported'
     rescue Error::Unauthorized
       unauthorized 'authentication failed'
+    end
+
+    # DELETE /session
+    def destroy
+      @current_user.authorizations.where(provider: 'tomatoes').destroy_all
+
+      head :no_content
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   # See how all your routes lay out with "rake routes".
 
   namespace :api do
-    resource :session, only: [:create]
+    resource :session, only: [:create, :destroy]
   end
 
   resources :tags, only: [:index, :show]


### PR DESCRIPTION
The endpoint destroys any open Tomatoes API session.

Example request:

    DELETE /api/session?token=123

See https://github.com/potomak/tomatoes/issues/15