### PR TITLE
Add leaderboards controllers

### DIFF
--- a/app/controllers/leaderboard/base_controller.rb
+++ b/app/controllers/leaderboard/base_controller.rb
@@ -1,0 +1,7 @@
+module Leaderboard
+  class BaseController < ApplicationController
+    def show
+      @leaderboard = collection.includes(:user).desc(:score).page(params[:page])
+    end
+  end
+end

--- a/app/controllers/leaderboard/dailies_controller.rb
+++ b/app/controllers/leaderboard/dailies_controller.rb
@@ -1,0 +1,10 @@
+module Leaderboard
+  class DailiesController < BaseController
+
+    private
+
+    def collection
+      DailyScore
+    end
+  end
+end

--- a/app/controllers/leaderboard/monthlies_controller.rb
+++ b/app/controllers/leaderboard/monthlies_controller.rb
@@ -1,0 +1,10 @@
+module Leaderboard
+  class MonthliesController < BaseController
+
+    private
+
+    def collection
+      MonthlyScore
+    end
+  end
+end

--- a/app/controllers/leaderboard/overalls_controller.rb
+++ b/app/controllers/leaderboard/overalls_controller.rb
@@ -1,0 +1,10 @@
+module Leaderboard
+  class OverallsController < BaseController
+
+    private
+
+    def collection
+      OverallScore
+    end
+  end
+end

--- a/app/controllers/leaderboard/weeklies_controller.rb
+++ b/app/controllers/leaderboard/weeklies_controller.rb
@@ -1,0 +1,10 @@
+module Leaderboard
+  class WeekliesController < BaseController
+
+    private
+
+    def collection
+      WeeklyScore
+    end
+  end
+end

--- a/app/views/leaderboard/_leaderboard.html.erb
+++ b/app/views/leaderboard/_leaderboard.html.erb
@@ -1,0 +1,16 @@
+<% unless leaderboard.empty? %>
+  <ol start="<%= (25*(params[:page].to_i-1))+1 if params[:page] %>">
+    <% leaderboard.each do |item| %>
+      <% if item.user %>
+        <li class="block <%= content_for_user(item.user) { 'you' } %>">
+          <%= render partial: 'users/user', locals: { user: item.user } %>
+          <div class="count"><%= pluralize(item.score.to_i, 'tomato') %></div>
+        </li>
+      <% end %>
+    <% end %>
+  </ol>
+
+  <%= paginate leaderboard %>
+<% else %>
+  <p>No tomatoers here</p>
+<% end %>

--- a/app/views/leaderboard/_links.html.erb
+++ b/app/views/leaderboard/_links.html.erb
@@ -1,0 +1,5 @@
+Leaderboards:
+<%= link_to 'Daily', leaderboard_daily_path %>,
+<%= link_to 'Weekly', leaderboard_weekly_path %>,
+<%= link_to 'Monthly', leaderboard_monthly_path %>,
+<%= link_to 'Overall', leaderboard_overall_path %>

--- a/app/views/leaderboard/dailies/show.html.erb
+++ b/app/views/leaderboard/dailies/show.html.erb
@@ -1,0 +1,7 @@
+<h1>Daily leaderboard</h1>
+
+<p><%= render partial: 'leaderboard/links' %></p>
+
+<div class="leaderboard_list">
+  <%= render partial: 'leaderboard/leaderboard', locals: { leaderboard: @leaderboard } %>
+</div>

--- a/app/views/leaderboard/monthlies/show.html.erb
+++ b/app/views/leaderboard/monthlies/show.html.erb
@@ -1,0 +1,7 @@
+<h1>Monthly leaderboard</h1>
+
+<p><%= render partial: 'leaderboard/links' %></p>
+
+<div class="leaderboard_list">
+  <%= render partial: 'leaderboard/leaderboard', locals: { leaderboard: @leaderboard } %>
+</div>

--- a/app/views/leaderboard/overalls/show.html.erb
+++ b/app/views/leaderboard/overalls/show.html.erb
@@ -1,0 +1,7 @@
+<h1>Overall leaderboard</h1>
+
+<p><%= render partial: 'leaderboard/links' %></p>
+
+<div class="leaderboard_list">
+  <%= render partial: 'leaderboard/leaderboard', locals: { leaderboard: @leaderboard } %>
+</div>

--- a/app/views/leaderboard/weeklies/show.html.erb
+++ b/app/views/leaderboard/weeklies/show.html.erb
@@ -1,0 +1,7 @@
+<h1>Weekly leaderboard</h1>
+
+<p><%= render partial: 'leaderboard/links' %></p>
+
+<div class="leaderboard_list">
+  <%= render partial: 'leaderboard/leaderboard', locals: { leaderboard: @leaderboard } %>
+</div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -21,7 +21,7 @@
     </div>
   </div>
   <div class="right">
-    <%= render partial: 'shared/ranking_links' %><br/>
+    <%= render partial: 'leaderboard/links' %><br/>
     <%= link_to "API Reference", page_path('api_reference') %>,
     <%= link_to "How to", page_path('how_to') %>,
     <%= link_to "Statistics", statistics_path %><br/>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,12 @@ Rails.application.routes.draw do
   end
 
   resources :rankings, only: :index
+  namespace :leaderboard do
+    resource :daily, only: :show
+    resource :weekly, only: :show
+    resource :monthly, only: :show
+    resource :overall, only: :show
+  end
 
   resources :tomatoes do
     member do

--- a/test/functional/leaderboard/dailies_controller_test.rb
+++ b/test/functional/leaderboard/dailies_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+module Leaderboard
+  class DailiesControllerTest < ActionController::TestCase
+    include BaseControllerTest
+  end
+end

--- a/test/functional/leaderboard/monthlies_controller_test.rb
+++ b/test/functional/leaderboard/monthlies_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+module Leaderboard
+  class MonthliesControllerTest < ActionController::TestCase
+    include BaseControllerTest
+  end
+end

--- a/test/functional/leaderboard/overalls_controller_test.rb
+++ b/test/functional/leaderboard/overalls_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+module Leaderboard
+  class OverallsControllerTest < ActionController::TestCase
+    include BaseControllerTest
+  end
+end

--- a/test/functional/leaderboard/weeklies_controller_test.rb
+++ b/test/functional/leaderboard/weeklies_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+module Leaderboard
+  class WeekliesControllerTest < ActionController::TestCase
+    include BaseControllerTest
+  end
+end

--- a/test/support/leaderboard/base_controller_test.rb
+++ b/test/support/leaderboard/base_controller_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+module Leaderboard
+  module BaseControllerTest
+    extend ActiveSupport::Concern
+
+    included do
+      setup do
+        User.destroy_all
+        Tomato.delete_all
+
+        @user = User.create!(
+          name: 'name',
+          email: 'email@example.com'
+        )
+        @tomato = @user.tomatoes.create!(tag_list: 'one, two')
+      end
+
+      test 'should get show' do
+        get :show
+        assert_response :success
+        assert_not_nil assigns(:leaderboard)
+        assert_not_empty assigns(:leaderboard)
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,8 @@ require 'sucker_punch/testing/inline'
 require 'minitest/reporters'
 Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
 
+Dir[Rails.root.join('test/support/**/*.rb')].each { |f| require f }
+
 module ActiveSupport
   class TestCase
     # Setup all fixtures in test/fixtures/*.(yml|csv) for all tests in alphabetical order.


### PR DESCRIPTION
There are four new controllers:

1. `Leadeboard::DailiesController`
1. `Leadeboard::WeekliesController`
1. `Leadeboard::MonthliesController`
1. `Leadeboard::OverallsController`

and four new associated routes:

1. `GET /leaderboard/daily`
1. `GET /leaderboard/monthly`
1. `GET /leaderboard/weekly`
1. `GET /leaderboard/overall`

They refer respectively to the collections:

1. `DailyScore`
1. `WeeklyScore`
1. `MonthlyScore`
1. `OverallScore`

Controllers tests share the same code by including a support module.

The view leaderboard partial template doesn't rely on the dynamic *you* class anymore because it doesn't need to be cached. See also https://github.com/potomak/tomatoes/pull/193.

See https://github.com/potomak/tomatoes/issues/206.