### PR TITLE
Fix API's current user

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -5,6 +5,7 @@ module Api
     private
 
     def current_user
+      return unless params[:token]
       @current_user ||= User.find_by_token(params[:token])
     end
 

--- a/chrome_app/manifest.json
+++ b/chrome_app/manifest.json
@@ -1,1 +1,1 @@
-{"name":"Tomatoes","app":{"urls":["http://tomato.es/"],"launch":{"web_url":"http://tomato.es/"}},"icons":{"128":"icon_128.png"},"version":"0.12.1","description":"Pomodoro Technique\u00ae web-based time tracker"}
+{"name":"Tomatoes","app":{"urls":["http://tomato.es/"],"launch":{"web_url":"http://tomato.es/"}},"icons":{"128":"icon_128.png"},"version":"0.12.2","description":"Pomodoro Technique\u00ae web-based time tracker"}

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,7 @@ require 'bootstrap-social-rails'
 Bundler.require(*Rails.groups)
 
 module TomatoesApp
-  VERSION = '0.12.1'.freeze
+  VERSION = '0.12.2'.freeze
   REPO = 'https://github.com/potomak/tomatoes'.freeze
 
   class Application < Rails::Application

--- a/test/functional/api/users_controller_test.rb
+++ b/test/functional/api/users_controller_test.rb
@@ -5,10 +5,26 @@ module Api
     setup do
       @user = User.create!(name: 'name', email: 'email@example.com')
       @user.authorizations.create!(provider: 'tomatoes', token: '123')
+
+      @user_without_auths = User.create!(name: 'Nicolae', email: 'nic@example.com')
     end
 
     teardown do
       User.destroy_all
+    end
+
+    test 'GET /show, given a nil token, it should return an error' do
+      get :show
+      assert_response :unauthorized
+      assert_equal 'application/json', @response.content_type
+      assert_equal({ error: 'authentication failed' }.to_json, @response.body)
+    end
+
+    test 'GET /show, given a blank token, it should return an error' do
+      get :show, token: ''
+      assert_response :unauthorized
+      assert_equal 'application/json', @response.content_type
+      assert_equal({ error: 'authentication failed' }.to_json, @response.body)
     end
 
     test 'GET /show, given an invalid token, it should return an error' do


### PR DESCRIPTION
`User.find_by_token(params[:token])` returns the first user that doesn't include any authorization embedded record if `params[:token]` is `nil`. Let's short circuit `current_user` if `params[:token]` is not present.

Fixes #222.