### PR TITLE
Accept authorization header and API reference update

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -5,8 +5,12 @@ module Api
     private
 
     def current_user
-      return unless params[:token]
-      @current_user ||= User.find_by_token(params[:token])
+      return unless auth_token
+      @current_user ||= User.find_by_token(auth_token)
+    end
+
+    def auth_token
+      request.headers['Authorization'] || params[:token]
     end
 
     def authenticate_user!

--- a/app/views/pages/api_reference.html.md
+++ b/app/views/pages/api_reference.html.md
@@ -51,12 +51,10 @@ POST /api/session
 
 Deletes all Tomatoes API active sessions for the current user.
 
-#### Request content
+#### Auth header example
 
-```json
-{
-  "token": "d994a295cf68342b99e3036827d3ef8a"
-}
+```
+Authorization: d994a295cf68342b99e3036827d3ef8a
 ```
 
 #### Response
@@ -72,12 +70,10 @@ Deletes all Tomatoes API active sessions for the current user.
 
 Returns current user's data.
 
-#### Request content
+#### Auth header example
 
-```json
-{
-  "token": "d994a295cf68342b99e3036827d3ef8a"
-}
+```
+Authorization: d994a295cf68342b99e3036827d3ef8a
 ```
 
 #### Response
@@ -123,11 +119,16 @@ Returns current user's data.
 
 Updates current user's attributes.
 
+#### Auth header example
+
+```
+Authorization: d994a295cf68342b99e3036827d3ef8a
+```
+
 #### Request content
 
 ```json
 {
-  "token": "d994a295cf68342b99e3036827d3ef8a",
   "user": {
     "name": "Giovanni",
     "email": "giovanni@tomato.es",
@@ -195,14 +196,16 @@ The list of tomatoes is ordered by descending creation date and it's paginated.
 Each page contains 25 records, by default the first page is retuned, use the
 `page` parameter to get any other page in the range [1, `total_pages`].
 
-#### Request content
+#### Auth header example
 
-```json
-{
-  "token": "d994a295cf68342b99e3036827d3ef8a",
-  "page": 1
-}
 ```
+Authorization: d994a295cf68342b99e3036827d3ef8a
+```
+
+#### Request parameters
+
+* `page` a positive integer value to select a page in the range
+  [1, `total_pages`]
 
 #### Response
 
@@ -239,12 +242,10 @@ Each page contains 25 records, by default the first page is retuned, use the
 
 Returns one of current user's tomatoes.
 
-#### Request content
+#### Auth header example
 
-```json
-{
-  "token": "d994a295cf68342b99e3036827d3ef8a"
-}
+```
+Authorization: d994a295cf68342b99e3036827d3ef8a
 ```
 
 #### Response
@@ -268,11 +269,16 @@ Returns one of current user's tomatoes.
 
 Creates a new tomato.
 
+#### Auth header example
+
+```
+Authorization: d994a295cf68342b99e3036827d3ef8a
+```
+
 #### Request content
 
 ```json
 {
-  "token": "d994a295cf68342b99e3036827d3ef8a",
   "tomato": {
     "tag_list": "one, two"
   }
@@ -308,11 +314,16 @@ Creates a new tomato.
 
 Updates one of current user's tomatoes.
 
+#### Auth header example
+
+```
+Authorization: d994a295cf68342b99e3036827d3ef8a
+```
+
 #### Request content
 
 ```json
 {
-  "token": "d994a295cf68342b99e3036827d3ef8a",
   "tomato": {
     "tag_list": "one, two"
   }
@@ -340,12 +351,10 @@ Updates one of current user's tomatoes.
 
 Deletes one of current user's tomatoes.
 
-#### Request content
+#### Auth header example
 
-```json
-{
-  "token": "d994a295cf68342b99e3036827d3ef8a"
-}
+```
+Authorization: d994a295cf68342b99e3036827d3ef8a
 ```
 
 #### Response
@@ -366,14 +375,16 @@ The list of projects is ordered by descending creation date and it's paginated.
 Each page contains 25 records, by default the first page is retuned, use the
 `page` parameter to get any other page in the range [1, `total_pages`].
 
-#### Request content
+#### Auth header example
 
-```json
-{
-  "token": "d994a295cf68342b99e3036827d3ef8a",
-  "page": 1
-}
 ```
+Authorization: d994a295cf68342b99e3036827d3ef8a
+```
+
+#### Request parameters
+
+* `page` a positive integer value to select a page in the range
+  [1, `total_pages`]
 
 #### Response
 
@@ -407,12 +418,10 @@ Each page contains 25 records, by default the first page is retuned, use the
 
 Returns one of current user's projects.
 
-#### Request content
+#### Auth header example
 
-```json
-{
-  "token": "d994a295cf68342b99e3036827d3ef8a"
-}
+```
+Authorization: d994a295cf68342b99e3036827d3ef8a
 ```
 
 #### Response
@@ -439,11 +448,16 @@ Returns one of current user's projects.
 
 Creates a new project.
 
+#### Auth header example
+
+```
+Authorization: d994a295cf68342b99e3036827d3ef8a
+```
+
 #### Request content
 
 ```json
 {
-  "token": "d994a295cf68342b99e3036827d3ef8a",
   "project": {
     "name": "Web app",
     "tag_list": "ruby, acme",
@@ -485,11 +499,16 @@ Creates a new project.
 
 Updates one of current user's projects.
 
+#### Auth header example
+
+```
+Authorization: d994a295cf68342b99e3036827d3ef8a
+```
+
 #### Request content
 
 ```json
 {
-  "token": "d994a295cf68342b99e3036827d3ef8a",
   "project": {
     "name": "Web app",
     "tag_list": "ruby, acme",
@@ -523,12 +542,10 @@ Updates one of current user's projects.
 
 Deletes one of current user's projects.
 
-#### Request content
+#### Auth header example
 
-```json
-{
-  "token": "d994a295cf68342b99e3036827d3ef8a"
-}
+```
+Authorization: d994a295cf68342b99e3036827d3ef8a
 ```
 
 #### Response

--- a/chrome_app/manifest.json
+++ b/chrome_app/manifest.json
@@ -1,1 +1,1 @@
-{"name":"Tomatoes","app":{"urls":["http://tomato.es/"],"launch":{"web_url":"http://tomato.es/"}},"icons":{"128":"icon_128.png"},"version":"0.12.2","description":"Pomodoro Technique\u00ae web-based time tracker"}
+{"name":"Tomatoes","app":{"urls":["http://tomato.es/"],"launch":{"web_url":"http://tomato.es/"}},"icons":{"128":"icon_128.png"},"version":"0.12.3","description":"Pomodoro Technique\u00ae web-based time tracker"}

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,7 @@ require 'bootstrap-social-rails'
 Bundler.require(*Rails.groups)
 
 module TomatoesApp
-  VERSION = '0.12.2'.freeze
+  VERSION = '0.12.3'.freeze
   REPO = 'https://github.com/potomak/tomatoes'.freeze
 
   class Application < Rails::Application

--- a/test/functional/api/users_controller_test.rb
+++ b/test/functional/api/users_controller_test.rb
@@ -34,6 +34,14 @@ module Api
       assert_equal({ error: 'authentication failed' }.to_json, @response.body)
     end
 
+    test 'GET /show, given a headr authorization token, it should return current user' do
+      @request.headers['Authorization'] = '123'
+      get :show
+      assert_response :success
+      assert_equal 'application/json', @response.content_type
+      assert_equal Api::Presenter::User.new(@user).to_json, @response.body
+    end
+
     test 'GET /show, it should return current user' do
       get :show, token: '123'
       assert_response :success


### PR DESCRIPTION
Introduces a new `Authorization` header that could be used to pass an API session token, see #194.

Update API reference doc to add `Authorization` header as the default method to pass a session token and remove request bodies from GET requests examples, see #192.

cc @giorgia @pablosproject